### PR TITLE
Fix extension removal on Plesk 12.0

### DIFF
--- a/plib/scripts/pre-uninstall.php
+++ b/plib/scripts/pre-uninstall.php
@@ -1,4 +1,0 @@
-<?php
-// Copyright 1999-2016. Parallels IP Holdings GmbH.
-
-pm_Settings::clean();


### PR DESCRIPTION
There is no method pm_Settings::clean() in Plesk 12.0 SDK so the extension removal fails.
But in fact pm_Settings are cleared automatically on the extension removal in all supported Plesk versions. So you don't need do anything before the removal.
